### PR TITLE
Add tag attribute color

### DIFF
--- a/colors/codedark.vim
+++ b/colors/codedark.vim
@@ -110,7 +110,7 @@ let s:cdDiffGreenLight = {'gui': '#4B5632', 'cterm': s:cterm09, 'cterm256': '58'
 let s:cdDiffBlueLight = {'gui': '#87d7ff', 'cterm': s:cterm0C, 'cterm256': '117'}
 let s:cdDiffBlue = {'gui': '#005f87', 'cterm': s:cterm0D, 'cterm256': '24'}
 
-let s:cdSearchCurrent = {'gui': '#4B5632', 'cterm': s:cterm09, 'cterm256': '58'} 
+let s:cdSearchCurrent = {'gui': '#4B5632', 'cterm': s:cterm09, 'cterm256': '58'}
 let s:cdSearch = {'gui': '#264F78', 'cterm': s:cterm03, 'cterm256': '24'}
 
 " Syntax colors:
@@ -301,6 +301,7 @@ call <sid>hiTS('@text.literal', 'TSLiteral', s:cdYellowOrange, {}, 'none', {})
 call <sid>hiTS('@text.uri', 'TSURI', s:cdYellowOrange, {}, 'none', {})
 " Tags
 call <sid>hiTS('@tag', 'TSTag', s:cdBlue, {}, 'none', {})
+call <sid>hiTS('@tag.attribute', 'TSTagAttribute', s:cdLightBlue, {}, 'none', {})
 call <sid>hiTS('@tag.delimiter', 'TSTagDelimiter', s:cdGray, {}, 'none', {})
 
 " Markdown:


### PR DESCRIPTION
## Introduction 
I'm using `codedark` with `nvim 0.8.1`, `treesitter` & Svelte. I was able to fix the colorscheme easily thanks to your PR.

This PR is a little addition that helps color the tag's attributes in another color. Light blue here.

## Colored tag attributes with lightblue color.

Before:
![Screenshot-2022-12-11T19-51-26](https://user-images.githubusercontent.com/16125588/206925552-201b68cb-800d-4e70-8518-a94f34814ad2.png)

After:
![Screenshot-2022-12-11T19-51-42](https://user-images.githubusercontent.com/16125588/206925548-4e02540f-5038-4a00-bd5e-ef0e220ddfe5.png)

